### PR TITLE
Remove dynamicIO to support on-demand revalidation

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -12,7 +12,7 @@ export const POST = async () => {
       return response;
     }
 
-    revalidateTag("articles");
+    revalidateTag("newsArticle");
     const response = new Response("success", { status: 200 });
     console.log("Revalidation triggered for articles");
     return response;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,17 @@
 import { getNewsArticles } from "@/lib/contentful";
 import { NewsCard } from "@/components/news-card";
+import { unstable_cache } from "next/cache";
+
+const getCachedArticles = unstable_cache(
+  async () => {
+    return await getNewsArticles();
+  },
+  ["newsArticle"],
+  { revalidate: 60, tags: ["newsArticle"] }
+);
 
 export default async function Home() {
-  const articles = await getNewsArticles();
+  const articles = await getCachedArticles();
 
   return (
     <div className="min-h-screen bg-background">

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -1,7 +1,6 @@
 import { NewsArticleSkeleton } from "@/types/contentful";
 import { Document } from "@contentful/rich-text-types";
 import { createClient } from "contentful";
-import { unstable_cacheTag as cacheTag } from "next/cache";
 import { draftMode } from "next/headers";
 
 export const createContentfulClient = (preview: boolean) => {
@@ -27,9 +26,6 @@ export interface NewsArticle {
 }
 
 export async function getNewsArticles(): Promise<NewsArticle[]> {
-  "use cache";
-  cacheTag("newsArticle");
-
   const { isEnabled } = await draftMode();
   const client = createContentfulClient(isEnabled);
 
@@ -55,8 +51,6 @@ export async function getNewsArticles(): Promise<NewsArticle[]> {
 export async function getNewsArticleBySlug(
   slug: string
 ): Promise<NewsArticle | null> {
-  "use cache";
-  cacheTag("newsArticle", slug);
   const { isEnabled } = await draftMode();
   const client = createContentfulClient(isEnabled);
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,7 +11,6 @@ const nextConfig: NextConfig = {
     ],
   },
   experimental: {
-    dynamicIO: true,
     ppr: "incremental",
   },
 };


### PR DESCRIPTION
Having dynamicIO enabled breaks pages once they are revalidated via revalidateTag. This PR disable dynamicIO and switches to unstable_cache and ISR for caching.